### PR TITLE
fix: allow extra env vars in Settings for library use

### DIFF
--- a/src/filemaker_mcp/config.py
+++ b/src/filemaker_mcp/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     @property
     def odata_base_url(self) -> str:


### PR DESCRIPTION
## Summary
- Adds `"extra": "ignore"` to the pydantic-settings `model_config` in `Settings`
- Without this, importing filemaker-mcp as a library dependency in a project that defines its own env vars (e.g., `ANTHROPIC_API_KEY`, `GHL_API_KEY`) causes a `ValidationError` at import time
- No behavior change when used as a standalone MCP server — unknown env vars are simply ignored instead of rejected

## Test plan
- [x] Verify standalone MCP server still works (only FM env vars present)
- [x] Verify library import works when extra env vars are in the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)