### PR TITLE
fix: bootstrap OData discovery when DDL script is missing

### DIFF
--- a/src/filemaker_mcp/tools/schema.py
+++ b/src/filemaker_mcp/tools/schema.py
@@ -473,12 +473,12 @@ async def bootstrap_ddl() -> None:
         logger.info("DDL bootstrap step 1: script probe succeeded")
     except ValueError as e:
         if "not found" in str(e).lower():
-            logger.info("DDL bootstrap step 1: script not found, using static DDL")
+            logger.info("DDL bootstrap step 1: script not found, falling through to OData discovery")
             set_script_available(False)
-            return
-        # Other ValueError — script exists but errored, continue
-        set_script_available(True)
-        logger.warning("DDL bootstrap step 1: probe returned error, continuing: %s", e)
+        else:
+            # Other ValueError — script exists but errored, continue
+            set_script_available(True)
+            logger.warning("DDL bootstrap step 1: probe returned error, continuing: %s", e)
     except PermissionError:
         logger.error("DDL bootstrap step 1: authentication failed, skipping bootstrap")
         return


### PR DESCRIPTION
## Summary
- When the DDL script (`SCR_DDL_GetTableDDL`) is not found on the FM server, `bootstrap_ddl()` now falls through to Step 2 (OData service document discovery) instead of returning immediately
- Previously relied on static DDL fallback, which is empty in this repo — resulting in zero tables discovered
- Tested against Fleet database: 14 tables correctly discovered

## Root cause
The `return` statement on the "script not found" branch short-circuited the entire bootstrap, skipping OData discovery entirely.

## Test plan
- [x] Verified against FM database without DDL script (Fleet) — 14 tables discovered
- [x] No regression for databases with DDL script (discovery still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)